### PR TITLE
fixed in memory file saving and base64 encoding for python 3

### DIFF
--- a/JSAnimation/html_writer.py
+++ b/JSAnimation/html_writer.py
@@ -3,7 +3,7 @@ import sys
 import random
 import string
 import warnings
-if sys.version_info < (3, 2):
+if sys.version_info < (3, 0):
     from cStringIO import StringIO as InMemory
 else:
     from io import BytesIO as InMemory


### PR DESCRIPTION
Fixed py3k and tested on linux. Other OS should work fine.
